### PR TITLE
Add docker compose configuration

### DIFF
--- a/docker-compose-development.yml
+++ b/docker-compose-development.yml
@@ -1,0 +1,44 @@
+version: '3.2'
+services:
+  web:
+    image: ulfri/timetable
+    # Rewrite github repository with the code in the current directory
+    volumes:
+      - type: bind
+        source: .
+        target: /home/timetable/urnik
+
+    ports:
+      - "8080:8080"
+    links:
+      - db
+    environment:
+      - DJANGO_SETTINGS_MODULE=urnik_fri.settings_example
+      - SECRET_KEY=type_your_secret_key
+      - UWSGI_CHDIR=/home/timetable/urnik
+      - UWSGI_MODULE=urnik_fri.wsgi_example:application
+      - UWSGI_MASTER=Tru
+      - UWSGI_PIDFILE=/tmp/project-master.pid
+      - UWSGI_VACUUM=True
+      - UWSGI_MAX_REQUESTS=5000
+      - UWSGI_UID=timetable
+      - UWSGI_GID=timetable
+      - UWSGI_HTTP_SOCKET=:8080
+      - UWSGI_PLUGINS=python3
+      - UWSGI_STATIC_MAP=/static=/home/timetable/static
+      - UWSGI_PY_AUTORELOAD=1
+    restart: always
+
+
+  db:
+    image: postgres
+    volumes:
+      - timetable-data:/var/lib/postgresql/data
+    restart: always
+    environment:
+      - POSTGRES_USER=timetable
+      - POSTGRES_DB=timetable
+      - POSTGRES_PASSWORD=database_password
+
+volumes:
+  timetable-data:

--- a/docker-compose-production.yml
+++ b/docker-compose-production.yml
@@ -1,0 +1,38 @@
+version: '3.2'
+services:
+  web:
+    image: ulfri/timetable
+    # Rewrite github repository with the code in the current directory
+    ports:
+      - "8080:8080"
+    links:
+      - db
+    environment:
+      - DJANGO_SETTINGS_MODULE=urnik_fri.settings_example
+      - SECRET_KEY=type_your_secret_key
+      - UWSGI_CHDIR=/home/timetable/urnik
+      - UWSGI_MODULE=urnik_fri.wsgi_example:application
+      - UWSGI_MASTER=Tru
+      - UWSGI_PIDFILE=/tmp/project-master.pid
+      - UWSGI_VACUUM=True
+      - UWSGI_MAX_REQUESTS=5000
+      - UWSGI_UID=timetable
+      - UWSGI_GID=timetable
+      - UWSGI_SOCKET=:8080
+      - UWSGI_PLUGINS=python3
+      - UWSGI_STATIC_MAP=/static=/home/timetable/static
+      - UWSGI_PY_AUTORELOAD=1
+    restart: always
+
+  db:
+    image: postgres
+    volumes:
+      - timetable-data:/var/lib/postgresql/data
+    restart: always
+    environment:
+      - POSTGRES_USER=timetable
+      - POSTGRES_DB=timetable
+      - POSTGRES_PASSWORD=database_password
+
+volumes:
+  timetable-data:


### PR DESCRIPTION
Two configuration files for two environments.

The developer environment speaks HTTP instead
of UWSGI, auto-reloads on code change and mounts
developers code inside container over the Github
urnik master branch.