### PR TITLE
Fix exchange to work after the shortName re_name

### DIFF
--- a/exchange/controllers.py
+++ b/exchange/controllers.py
@@ -554,7 +554,7 @@ def get_allocation_exchange_group(allocation):
     Returns:
         (Optional[Group]): The matching timetable group or None if no such group exists.
     """
-    groups = allocation.activityRealization.groups.filter(shortName__startswith=TIMETABLE_EXCHANGE_GROUP_PREFIX)
+    groups = allocation.activityRealization.groups.filter(short_name__startswith=TIMETABLE_EXCHANGE_GROUP_PREFIX)
     return groups.first()
 
 

--- a/exchange/tests.py
+++ b/exchange/tests.py
@@ -42,7 +42,7 @@ class BaseTestCase(TestCase):
     (--natural-primary and --natural-foreign need to be specified for integrity reasons, see the dumpdata docs)
     """
 
-    PERSISTENT_FIXTURE = "../test_fixtures/urnik-2017-11-09-00-00-02.json"
+    PERSISTENT_FIXTURE = "../test_fixtures/urnik-2017-11-09-00-00-02-shortnamerename.json"
     """A django dump of the whole database. Must NOT be inside `cls.fixtures` because we use a different strategy."""
 
     TESTING_TIMETABLE_SLUG = "fri-2017_2018-zimski"


### PR DESCRIPTION
A missing rename failed tests. Also probably the reason why production is crashing now. This fixes the issue.