### PR TITLE
Improve mobile and narrow width device display

### DIFF
--- a/friprosveta/static/css/allocations.css
+++ b/friprosveta/static/css/allocations.css
@@ -35,6 +35,18 @@ body {
     margin: auto;
 }
 
+@media (max-width: 35em) {
+    .grid-day {
+        font-size: 1.5ex;
+    }
+}
+
+@media (max-width: 30em) {
+    .grid-day {
+        font-size: 1.3ex;
+    }
+}
+
 .grid-hour {
     grid-column: hour-column-start / hour-column-end;
     margin: auto;
@@ -138,9 +150,21 @@ a.link-teacher {
     font-size: small;
 }
 
+@media (max-width: 35em) {
+    a.link-teacher {
+        font-size: 1.2ex;
+    }
+}
+
 a.link-group {
     font-size: x-small;
     color: rgba(23, 23, 23, 0.71);
+}
+
+@media (max-width: 35em) {
+    a.link-group {
+        display: none;
+    }
 }
 
 a.link-management {


### PR DESCRIPTION
Resizes or hides specific elements when the available horizontal space for text is too small, which significantly improves clarity. Requires a collectstatic.

Screenshots with #20 applied:
[Dense view - before](https://user-images.githubusercontent.com/8071628/38955723-c367208c-4355-11e8-9585-1833d505668d.png)
[Dense view - after](https://user-images.githubusercontent.com/8071628/38955719-c04c6240-4355-11e8-8e34-9b87bdd17f29.png)
[Sparse view - after](https://user-images.githubusercontent.com/8071628/38955729-c598eaac-4355-11e8-88b8-f07c70fb5f8e.png)

