### PR TITLE
Popup naj ostane dokler je miška nad njim

### DIFF
--- a/friprosveta/static/css/allocations.css
+++ b/friprosveta/static/css/allocations.css
@@ -114,8 +114,9 @@ body {
     text-align: center;
 }
 
-a.link-subject:hover ~ .entry-hover {
+a.link-subject:hover ~ .entry-hover, .entry-hover:hover {
     display: block;
+    pointer-events: auto;
 }
 
 a {


### PR DESCRIPTION
Na skrajnem desnem robu urnika popup z več informacijami ni viden. Možno ga je prebrati, če se pomakneš v desno, a v tem primeru hitro izgine.  
Predlagana sprememba ohrani popup dokler je miška nad njim, kar pomeni ne le, da ga lahko prebereš ko je ob robu, ampak omogoča tudi izbiranje besedila na njem.

## Prej:
![2019-10-18-12-15-15](https://user-images.githubusercontent.com/3891092/67089830-e036d380-f1a8-11e9-979f-880d65dc1ffa.gif)

## Zdaj:
![2019-10-18-12-16-45](https://user-images.githubusercontent.com/3891092/67089872-f0e74980-f1a8-11e9-9b43-e58e61721903.gif)
