### PR TITLE
Added extended json view of allocations

### DIFF
--- a/friprosveta/views.py
+++ b/friprosveta/views.py
@@ -491,20 +491,20 @@ def allocations_json(request, timetable_slug=None):
                 allocation.day_index = weekday_mapping[allocation.day]
                 allocation.hour_index = hour_mapping[allocation.start]
             allocation_vms = sorted(filtered_allocations, key=lambda avm: avm.day_index)
-            allocations_by_day = [(d, list(avm_grouper))
-                                  for d, avm_grouper in itertools.groupby(allocation_vms, lambda avm: avm.day)]
+            allocations_by_day = [(day, list(avm_grouper))
+                                  for day, avm_grouper in itertools.groupby(allocation_vms, lambda avm: avm.day)]
             allocations_ext = dict() 
             for day, allocations in allocations_by_day:
                 allocations_day = []
-                for subject in allocations:
-                    teachers = [str(i) for i in subject.activityRealization.teachers.all()]
+                for allocation in allocations:
+                    teachers = [str(i) for i in allocation.teachers.all()]
                     allocation_single = {
-                        "name":subject.activityRealization.activity.name,
-                        "tag":subject.activityRealization.activity.short_name,
-                        "classroom":str(subject.classroom),
-                        "durration":subject.duration,
-                        "start":subject.start,  
-                        "type":subject.activityRealization.activity.type,
+                        "name":allocation.activityRealization.activity.name,
+                        "tag":allocation.activityRealization.activity.short_name,
+                        "classroom":str(allocation.classroom),
+                        "durration":allocation.duration,
+                        "start":allocation.start,  
+                        "type":allocation.activityRealization.activity.type,
                         "teachers":teachers          
                     } 
                     allocations_day.append(allocation_single)


### PR DESCRIPTION
Added an extended json view of allocations when viewing allocations.
To see the extended view just add another parameter (mode=ext). Example use
/timetable/fri-2019_2020-letni-1-9/allocations.json?classroom=126&mode=ext

Returned json will contain subjects/allocations sorted by day. For every allocation there is a name, short name(tag), classroom, duration, start time, type and teachers. 
This was made as part of my assignment for the subject RVP (Računalništvo v praksi).